### PR TITLE
Fix potential security-vulnerability.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ gem 'github-pages', group: :jekyll_plugins
 gem 'rmagick'
 gem 'jekyll-responsive_image'
 gem 'jekyll-paginate'
-gem 'nokogiri', '>=1.6.8.rc3'
+gem "nokogiri", ">= 1.8.2"
 
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?


### PR DESCRIPTION
Bump up "nokogiri" to version 1.8.2 to fix
CVE-2017-18258 as suggested by the Github alert.

Signed-off-by: Christopher Métrailler <metc@users.noreply.github.com>