### PR TITLE
Updates links on download page

### DIFF
--- a/_pages/download.md
+++ b/_pages/download.md
@@ -24,14 +24,12 @@ Here you can find the latest development snapshot(s). This versions have not bee
 
 Use them on your own risk and make backups of your maps in order to avoid trouble.
 
-*For 1.12 development, there are currently no available jars. You will need to go to the following link and compile it yourself.*
+*For 1.16+ development, the mod is not in a playable state yet, and thus there are no available jars for download. In order to work on the project, you will need to compile the source yourself using the instructions provided on the repository.*
 
-<a class="btn btn-lg btn-primary" href="https://github.com/Electrical-Age/ElectricalAge/tree/ports/1.10" role="button">1.12 Development Repository</a>
+<a class="btn btn-lg btn-primary" href="https://github.com/eln2/eln2" role="button">1.16+ Development Repository</a>
 
 *For unofficial 1.7.10 development, please visit the following link for jrddunbr's GitHub releases page.*
 
 <a class="btn btn-lg btn-primary" href="https://github.com/jrddunbr/ElectricalAge/releases" role="button">1.7.10 Unofficial Release Jars</a>
 
 <br/><br/><br/>
-
-


### PR DESCRIPTION
This fixes #22 on GitHub

* Removes 1.12 link to old port atempt
* Adds new 1.16+ link to new port atempt
* Modifies message to the user above the link to the new code

Note: I was unable to test this as the testing infrastructure for running Jekyll locally is broken.