### PR TITLE
Add news post for new 1.17.0 version

### DIFF
--- a/_posts/2020-04-22-release-1.17.0.md
+++ b/_posts/2020-04-22-release-1.17.0.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: 1.17.0 Released
+permalink: news/release-1-17/
+---
+
+This is a rollup release for various bugfixes / improvements(?) that made it into code but haven't been released.
+
+### Highlights:
+
+- The electrical tools (axe / pickaxe) now have treecapitation and area-mining modes. These are enabled by defaults; right-click to toggle.
+- The portable battery packs have been buffed accordingly. You may still need more than one for continuous mining.
+- The 200V machines are now significantly faster, but draw more power. This may give the 50V machines a niche further into the game. Be careful not to explode your base.
+- Creosote is now a valid fuel for the fuel heat furnace.
+- An improved flashlight with significantly more range has been added.
+- Various bugfixes to the PID and other chips.
+- The autominer now supports ores with multiple item drops.
+- Most/all icons have been swapped for more easily recognizable versions.
+- There is a new emergency lamp item, which can be powered off an internal battery.
+- There is a new 'scanner' item, which in principle duplicates the functionality of the vanilla comparator, but outputs an analog circuit signal instead of a 0-15 redstone value. It may or may not work.
+
+ This update can be downloaded from CurseForge [here](https://www.curseforge.com/minecraft/mc-mods/electrical-age/files/2937618).
+
+Progress is continuing (somewhat faster) on the rewrite/port, now targeting Minecraft ~~1.15~~ 1.16 or newer, as of Feb 14, 2021.
+
+No warranty included.


### PR DESCRIPTION
This commit adds a news post to update the news on the website (last updated in 2016) with an update on the version of Electrical Age to 1.17.0.

Odds are if #22 is merged that this will need rebasing, I can do that if necessary.

Please note that I was unable to test this page in the same manner as in #22 where I cannot run `jekyll serve` to test the contents.